### PR TITLE
BREAKING CHANGE: Change is.OK(bool) -> is.True(bool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Professional lightweight testing mini-framework for Go.
 
 * Easy to write and read
-* [Beautifully simple API](https://godoc.org/github.com/matryer/is) with everything you need: `is.Equal`, `is.OK`, `is.NoErr`, and `is.Fail`
+* [Beautifully simple API](https://godoc.org/github.com/matryer/is) with everything you need: `is.Equal`, `is.True`, `is.NoErr`, and `is.Fail`
 * Use comments to add descriptions (which show up when tests fail)
 
 Failures are very easy to read:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ func Test(t *testing.T) {
 	is.Equal(signedin, true) // must be signed in
 	
 	body := readBody(r)
-	is.OK(strings.Contains(body, "Hi there"))
+	is.True(strings.Contains(body, "Hi there"))
 	
 }
 ```

--- a/is.go
+++ b/is.go
@@ -109,21 +109,21 @@ func (is *I) Fail() {
 	is.log("failed")
 }
 
-// OK asserts that the expression is true. The expression
+// True asserts that the expression is true. The expression
 // code itself will be reported if the assertion fails.
 //
 // 	func Test(t *testing.T) {
 //		is := is.New(t)
 //		val := method()
-//		is.OK(val != nil) // val should never be nil
+//		is.True(val != nil) // val should never be nil
 //	}
 //
 // Will output:
 //
-// 	your_test.go:123: not ok: val != nil
-func (is *I) OK(expression bool) {
+// 	your_test.go:123: not true: val != nil
+func (is *I) True(expression bool) {
 	if !expression {
-		is.log("not ok: $ARGS")
+		is.log("not true: $ARGS")
 	}
 }
 

--- a/is_test.go
+++ b/is_test.go
@@ -143,11 +143,11 @@ var tests = []struct {
 
 	// OK
 	{
-		N: "OK(1 == 2)",
+		N: "True(1 == 2)",
 		F: func(is *I) {
-			is.OK(1 == 2)
+			is.True(1 == 2)
 		},
-		Fail: "not ok: 1 == 2",
+		Fail: "not true: 1 == 2",
 	},
 }
 
@@ -195,7 +195,7 @@ func TestRelaxed(t *testing.T) {
 	is.out = &buf
 	is.colorful = false
 	is.NoErr(errors.New("oops"))
-	is.OK(1 == 2)
+	is.True(1 == 2)
 	actual := buf.String()
 	if !strings.Contains(actual, `oops`) {
 		t.Errorf("missing: oops")

--- a/testdata/example_test.go
+++ b/testdata/example_test.go
@@ -5,25 +5,25 @@ package example
 // throughout this file.
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestSomething(t *testing.T) {
-    // this comment will be extracted
+	// this comment will be extracted
 }
 
 func TestSomethingElse(t *testing.T) {
-    a, b := 1, 2
-    getB = func() int {
-        return b
-    }
-    is.OK(a == getB()) // should be the same
+	a, b := 1, 2
+	getB = func() int {
+		return b
+	}
+	is.True(a == getB()) // should be the same
 }
 
 func TestSomethingElseTpp(t *testing.T) {
-    a, b := 1, 2
-    getB = func() int {
-        return b
-    }
-    is.OK(a == getB())
+	a, b := 1, 2
+	getB = func() int {
+		return b
+	}
+	is.True(a == getB())
 }


### PR DESCRIPTION
`is.OK(bool)` is ambiguous. Other test asserting frameworks use `OK` as to ensure if code inside doesn't panic, which could lead to confusion.
`is.True(bool)` sounds more naturally and specifically tells what that piece of code does.