### PR TITLE
Update is.NewRelaxed documentation

### DIFF
--- a/is.go
+++ b/is.go
@@ -189,9 +189,9 @@ func (is *I) New(t *testing.T) *I {
 // pattern:
 //
 //	func Test(t *testing.T) {
-//		is := is.New(t)
+//		is := is.NewRelaxed(t)
 //		t.Run("sub", func(t *testing.T) {
-//			is := is.New(t)
+//			is := is.NewRelaxed(t)
 //			// TODO: test
 //		})
 //	}


### PR DESCRIPTION
Looks like the example was copy-and-pasted from is.New, without being updated to say "NewRelaxed"

Fixing this should make the documentation easier to understand, as the example references the correct function.