### PR TITLE
 #27: Escape '%' runes in lines before formatting 

### DIFF
--- a/is.go
+++ b/is.go
@@ -363,8 +363,7 @@ func (is *I) decorate(s string) string {
 		buf.WriteString(colorNormal)
 	}
 
-	// escape literal '%'s to prevent string formatting issues
-	s = strings.Replace(s, "%", "%%", -1)
+	s = escapeFormatString(s)
 
 	lines := strings.Split(s, "\n")
 	if l := len(lines); l > 1 && lines[l-1] == "" {
@@ -388,6 +387,7 @@ func (is *I) decorate(s string) string {
 			buf.WriteString(colorComment)
 		}
 		buf.WriteString(" // ")
+		comment = escapeFormatString(comment)
 		buf.WriteString(comment)
 		if is.colorful {
 			buf.WriteString(colorNormal)
@@ -395,6 +395,11 @@ func (is *I) decorate(s string) string {
 	}
 	buf.WriteString("\n")
 	return buf.String()
+}
+
+// escapeFormatString escapes strings for use in formatted functions like Sprintf.
+func escapeFormatString(fmt string) string {
+	return strings.Replace(fmt, "%", "%%", -1)
 }
 
 const (

--- a/is.go
+++ b/is.go
@@ -362,6 +362,10 @@ func (is *I) decorate(s string) string {
 	if is.colorful {
 		buf.WriteString(colorNormal)
 	}
+
+	// escape literal '%'s to prevent string formatting issues
+	s = strings.Replace(s, "%", "%%", -1)
+
 	lines := strings.Split(s, "\n")
 	if l := len(lines); l > 1 && lines[l-1] == "" {
 		lines = lines[:l-1]

--- a/is_test.go
+++ b/is_test.go
@@ -276,3 +276,17 @@ func TestSubtests(t *testing.T) {
 		is.Equal(1+1, 2)
 	})
 }
+
+// TestArgumentsEscape ensures strings are correctly escaped before printing.
+// https://github.com/matryer/is/issues/27
+func TestFormatStringEscape(t *testing.T) {
+	tt := &mockT{}
+	is := NewRelaxed(tt)
+	var buf bytes.Buffer
+	is.out = &buf
+	is.Equal("20%", "0.2")
+	actual := buf.String()
+	if strings.Contains(actual, `(MISSING)`) {
+		t.Errorf("string value was not escaped correctly")
+	}
+}

--- a/is_test.go
+++ b/is_test.go
@@ -140,6 +140,15 @@ var tests = []struct {
 		},
 		Fail: ``,
 	},
+	{
+		N: `Equal("20%", "0.2")`,
+		F: func(is *I) {
+			s1 := "20%"
+			s2 := "0.2"
+			is.Equal(s1, s2) // strings
+		},
+		Fail: ` // strings`,
+	},
 
 	// Fail
 	{

--- a/is_test.go
+++ b/is_test.go
@@ -293,9 +293,9 @@ func TestFormatStringEscape(t *testing.T) {
 	is := NewRelaxed(tt)
 	var buf bytes.Buffer
 	is.out = &buf
-	is.Equal("20% VAT", "0.2 VAT")
+	is.Equal("20% VAT", "0.2 VAT") // % symbol should be correctly printed
 	actual := buf.String()
-	if strings.Contains(actual, `%!V`) {
-		t.Errorf("string value was not escaped correctly: %s", actual)
+	if strings.Contains(actual, `%!`) {
+		t.Errorf("string was not escaped correctly: %s", actual)
 	}
 }

--- a/is_test.go
+++ b/is_test.go
@@ -141,10 +141,10 @@ var tests = []struct {
 		Fail: ``,
 	},
 	{
-		N: `Equal("20%", "0.2")`,
+		N: `Equal("20% VAT", "0.2 VAT")`,
 		F: func(is *I) {
-			s1 := "20%"
-			s2 := "0.2"
+			s1 := "20% VAT"
+			s2 := "0.2 VAT"
 			is.Equal(s1, s2) // strings
 		},
 		Fail: ` // strings`,
@@ -293,9 +293,9 @@ func TestFormatStringEscape(t *testing.T) {
 	is := NewRelaxed(tt)
 	var buf bytes.Buffer
 	is.out = &buf
-	is.Equal("20%", "0.2")
+	is.Equal("20% VAT", "0.2 VAT")
 	actual := buf.String()
-	if strings.Contains(actual, `(MISSING)`) {
-		t.Errorf("string value was not escaped correctly")
+	if strings.Contains(actual, `%!V`) {
+		t.Errorf("string value was not escaped correctly: %s", actual)
 	}
 }


### PR DESCRIPTION
Fixes #27 

- Added test to catch formatting issues
- Escape `%` runes in lines before formatting
- Added string example in `TestFailures`:
![Screenshot 2019-05-08 at 00 19 52](https://user-images.githubusercontent.com/1525809/57338925-2af6ee80-7127-11e9-9ba2-b4fd194f2db8.png)
