### PR TITLE
Add IS_NO_COLOR Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ func Test(t *testing.T) {
 
 ## Color
 
-To turn off the colors, run `go test` with the `-nocolor` flag.
+To turn off the colors, run `go test` with the `-nocolor` flag, or with the env var `IS_NO_COLOR=true`.
 
 ```
 go test -nocolor
+```
+
+```
+IS_NO_COLOR=true go test
 ```

--- a/is.go
+++ b/is.go
@@ -74,7 +74,8 @@ type I struct {
 var noColorFlag bool
 
 func init() {
-	flag.BoolVar(&noColorFlag, "nocolor", false, "turns off colors")
+	colorEnv := os.Getenv("IS_NO_COLOR") != "false"
+	flag.BoolVar(&noColorFlag, "nocolor", colorEnv, "turns off colors")
 }
 
 // New makes a new testing helper using the specified


### PR DESCRIPTION
#### Summary
Specifying `-nocolor` breaks `go test` unless `is` is present in at least one targeted package.  However `go test` will not mind `IS_NO_COLOR` env var even if `is` is not present in any targeted packages.

#### Example
*If the user specifies `-nocolor` flag in their test automation commands and the `is` package is not being imported by at least one of the matching packages, then the `go test` command will fail with the error `flag provided but not defined: -nocolor`.*

In my experience, this can happen when my editor's test-on-save flags include `-nocolor`, but I save a file in a package which doesn't import `is`.

This env var might also be useful when configuring CI systems.