### PR TITLE
Fix handling of the IS_NO_COLOR env variable

### DIFF
--- a/is.go
+++ b/is.go
@@ -74,8 +74,8 @@ type I struct {
 var noColorFlag bool
 
 func init() {
-	colorEnv := os.Getenv("IS_NO_COLOR") != "false"
-	flag.BoolVar(&noColorFlag, "nocolor", colorEnv, "turns off colors")
+	envNoColor := os.Getenv("IS_NO_COLOR") == "true"
+	flag.BoolVar(&noColorFlag, "nocolor", envNoColor, "turns off colors")
 }
 
 // New makes a new testing helper using the specified


### PR DESCRIPTION
To make it behave as documented in the README: 

> To turn off the colors (...) with the env var IS_NO_COLOR=true.

--- 

@matryer Thanks for this nice little package (and for all the other stuff that you do for the go community; especially `gotime` & `How (you) Write HTTP Web Services after XXX Years`)