### PR TITLE
Add Helper method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
+os:
+  - linux
+  - osx
+  - windows
+
 language: go
 
 sudo: required
 
 go:
+  # "1.x" always refers to the latest Go version, inc. the patch release.
+  # e.g. "1.x" is 1.13 until 1.13.1 is available.
+  - 1.x
   - 1.6.x
   - 1.7.x
   - 1.8.x
@@ -13,13 +21,19 @@ go:
   - 1.13.x
   - tip
 
-env:
-    - GIMME_OS=linux GIMME_ARCH=amd64
-    - GIMME_OS=darwin GIMME_ARCH=amd64
-    - GIMME_OS=windows GIMME_ARCH=amd64
+matrix:
+  allow_failures:
+    - os: windows
+      go: tip
+  exclude:
+      # OSX 1.6.4 is not present in travis.
+      # https://github.com/travis-ci/travis-ci/issues/10309
+    - go: 1.6.x
+      os: osx
 
 install:
-    - go get -d -v ./...
+  - go get -d -v ./...
 
 script:
-    - go build -v ./...
+  - go build -v ./...
+  - go test ./...

--- a/is-1.7.go
+++ b/is-1.7.go
@@ -1,0 +1,64 @@
+// +build go1.7
+
+package is
+
+import (
+	"regexp"
+	"runtime"
+)
+
+// Helper marks the calling function as a test helper function.
+// When printing file and line information, that function will be skipped.
+//
+// Available with Go 1.7 and later.
+func (is *I) Helper() {
+	is.helpers[callerName(1)] = struct{}{}
+}
+
+// callerName gives the function name (qualified with a package path)
+// for the caller after skip frames (where 0 means the current function).
+func callerName(skip int) string {
+	// Make room for the skip PC.
+	var pc [1]uintptr
+	n := runtime.Callers(skip+2, pc[:]) // skip + runtime.Callers + callerName
+	if n == 0 {
+		panic("is: zero callers found")
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+	return frame.Function
+}
+
+// The maximum number of stack frames to go through when skipping helper functions for
+// the purpose of decorating log messages.
+const maxStackLen = 50
+
+var reIsSourceFile = regexp.MustCompile("is(-1.7)?\\.go$")
+
+func (is *I) callerinfo() (path string, line int, ok bool) {
+	var pc [maxStackLen]uintptr
+	// Skip two extra frames to account for this function
+	// and runtime.Callers itself.
+	n := runtime.Callers(2, pc[:])
+	if n == 0 {
+		panic("is: zero callers found")
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	var firstFrame, frame runtime.Frame
+	for more := true; more; {
+		frame, more = frames.Next()
+		if reIsSourceFile.MatchString(frame.File) {
+			continue
+		}
+		if firstFrame.PC == 0 {
+			firstFrame = frame
+		}
+		if _, ok := is.helpers[frame.Function]; ok {
+			// Frame is inside a helper function.
+			continue
+		}
+		return frame.File, frame.Line, true
+	}
+	// If no "non-helper" frame is found, the first non is frame is returned.
+	return firstFrame.File, firstFrame.Line, true
+}

--- a/is-1.7_test.go
+++ b/is-1.7_test.go
@@ -1,0 +1,44 @@
+// +build go1.7
+
+package is
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestHelper(t *testing.T) {
+	tests := []struct {
+		name             string
+		helper           bool
+		expectedFilename string
+	}{
+		{
+			name:             "without helper",
+			helper:           false,
+			expectedFilename: "is_helper_test.go",
+		},
+		{
+			name:             "with helper",
+			helper:           true,
+			expectedFilename: "is-1.7_test.go",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := &mockT{}
+			is := NewRelaxed(tt)
+
+			var buf bytes.Buffer
+			is.out = &buf
+			helper(is, tc.helper)
+			actual := buf.String()
+			t.Log(actual)
+			if !strings.Contains(actual, tc.expectedFilename) {
+				t.Errorf("string does not contain correct filename: %s", actual)
+			}
+		})
+	}
+}

--- a/is-1.7_test.go
+++ b/is-1.7_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 )
 
+// TestSubtests ensures subtests work as expected.
+// https://github.com/matryer/is/issues/1
+func TestSubtests(t *testing.T) {
+	t.Run("sub1", func(t *testing.T) {
+		is := New(t)
+		is.Equal(1+1, 2)
+	})
+}
+
 func TestHelper(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/is-before-1.7.go
+++ b/is-before-1.7.go
@@ -1,0 +1,23 @@
+// +build !go1.7
+
+package is
+
+import (
+	"regexp"
+	"runtime"
+)
+
+var reIsSourceFile = regexp.MustCompile("is(-before-1.7)?\\.go$")
+
+func (is *I) callerinfo() (path string, line int, ok bool) {
+	for i := 0; ; i++ {
+		_, path, line, ok = runtime.Caller(i)
+		if !ok {
+			return
+		}
+		if reIsSourceFile.MatchString(path) {
+			continue
+		}
+		return path, line, true
+	}
+}

--- a/is.go
+++ b/is.go
@@ -45,7 +45,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -191,12 +190,6 @@ func (is *I) NewRelaxed(t *testing.T) *I {
 	return NewRelaxed(t)
 }
 
-// Helper marks the calling function as a test helper function.
-// When printing file and line information, that function will be skipped.
-func (is *I) Helper() {
-	is.helpers[callerName(1)] = struct{}{}
-}
-
 func (is *I) valWithType(v interface{}) string {
 	if isNil(v) {
 		return "<nil>"
@@ -252,52 +245,6 @@ func areEqual(a, b interface{}) bool {
 	aValue := reflect.ValueOf(a)
 	bValue := reflect.ValueOf(b)
 	return aValue == bValue
-}
-
-// callerName gives the function name (qualified with a package path)
-// for the caller after skip frames (where 0 means the current function).
-func callerName(skip int) string {
-	// Make room for the skip PC.
-	var pc [1]uintptr
-	n := runtime.Callers(skip+2, pc[:]) // skip + runtime.Callers + callerName
-	if n == 0 {
-		panic("is: zero callers found")
-	}
-	frames := runtime.CallersFrames(pc[:n])
-	frame, _ := frames.Next()
-	return frame.Function
-}
-
-// The maximum number of stack frames to go through when skipping helper functions for
-// the purpose of decorating log messages.
-const maxStackLen = 50
-
-func (is *I) callerinfo() (path string, line int, ok bool) {
-	var pc [maxStackLen]uintptr
-	// Skip two extra frames to account for this function
-	// and runtime.Callers itself.
-	n := runtime.Callers(2, pc[:])
-	if n == 0 {
-		panic("is: zero callers found")
-	}
-	frames := runtime.CallersFrames(pc[:n])
-	var firstFrame, frame runtime.Frame
-	for more := true; more; {
-		frame, more = frames.Next()
-		if strings.HasSuffix(frame.File, "is.go") {
-			continue
-		}
-		if firstFrame.PC == 0 {
-			firstFrame = frame
-		}
-		if _, ok := is.helpers[frame.Function]; ok {
-			// Frame is inside a helper function.
-			continue
-		}
-		return frame.File, frame.Line, true
-	}
-	// If no "non-helper" frame is found, the first non is frame is returned.
-	return firstFrame.File, firstFrame.Line, true
 }
 
 // loadComment gets the Go comment from the specified line

--- a/is_helper_test.go
+++ b/is_helper_test.go
@@ -1,0 +1,8 @@
+package is
+
+func helper(is *I, helper bool) {
+	if helper {
+		is.Helper()
+	}
+	is.True(false)
+}

--- a/is_helper_test.go
+++ b/is_helper_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package is
 
 func helper(is *I, helper bool) {

--- a/is_test.go
+++ b/is_test.go
@@ -299,38 +299,3 @@ func TestFormatStringEscape(t *testing.T) {
 		t.Errorf("string was not escaped correctly: %s", actual)
 	}
 }
-
-func TestHelper(t *testing.T) {
-	tests := []struct {
-		name             string
-		helper           bool
-		expectedFilename string
-	}{
-		{
-			name:             "without helper",
-			helper:           false,
-			expectedFilename: "is_helper_test.go",
-		},
-		{
-			name:             "with helper",
-			helper:           true,
-			expectedFilename: "is_test.go",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tt := &mockT{}
-			is := NewRelaxed(tt)
-
-			var buf bytes.Buffer
-			is.out = &buf
-			helper(is, tc.helper)
-			actual := buf.String()
-			t.Log(actual)
-			if !strings.Contains(actual, tc.expectedFilename) {
-				t.Errorf("string does not contain correct filename: %s", actual)
-			}
-		})
-	}
-}

--- a/is_test.go
+++ b/is_test.go
@@ -299,3 +299,38 @@ func TestFormatStringEscape(t *testing.T) {
 		t.Errorf("string was not escaped correctly: %s", actual)
 	}
 }
+
+func TestHelper(t *testing.T) {
+	tests := []struct {
+		name             string
+		helper           bool
+		expectedFilename string
+	}{
+		{
+			name:             "without helper",
+			helper:           false,
+			expectedFilename: "is_helper_test.go",
+		},
+		{
+			name:             "with helper",
+			helper:           true,
+			expectedFilename: "is_test.go",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := &mockT{}
+			is := NewRelaxed(tt)
+
+			var buf bytes.Buffer
+			is.out = &buf
+			helper(is, tc.helper)
+			actual := buf.String()
+			t.Log(actual)
+			if !strings.Contains(actual, tc.expectedFilename) {
+				t.Errorf("string does not contain correct filename: %s", actual)
+			}
+		})
+	}
+}

--- a/is_test.go
+++ b/is_test.go
@@ -277,15 +277,6 @@ func TestLoadArguments(t *testing.T) {
 	}
 }
 
-// TestSubtests ensures subtests work as expected.
-// https://github.com/matryer/is/issues/1
-func TestSubtests(t *testing.T) {
-	t.Run("sub1", func(t *testing.T) {
-		is := New(t)
-		is.Equal(1+1, 2)
-	})
-}
-
 // TestArgumentsEscape ensures strings are correctly escaped before printing.
 // https://github.com/matryer/is/issues/27
 func TestFormatStringEscape(t *testing.T) {


### PR DESCRIPTION
Helper marks the calling function as a test helper function.
When printing file and line information, that function will be skipped.

Adopted from testings.Helper from the stdlib.

Related: #30