### PR TITLE
Use pkg.go.dev instead of godoc.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Professional lightweight testing mini-framework for Go.
 
 * Easy to write and read
-* [Beautifully simple API](https://godoc.org/github.com/matryer/is) with everything you need: `is.Equal`, `is.True`, `is.NoErr`, and `is.Fail`
+* [Beautifully simple API](https://pkg.go.dev/github.com/matryer/is) with everything you need: `is.Equal`, `is.True`, `is.NoErr`, and `is.Fail`
 * Use comments to add descriptions (which show up when tests fail)
 
 Failures are very easy to read:
@@ -18,14 +18,14 @@ the helper methods:
 func Test(t *testing.T) {
 
 	is := is.New(t)
-	
+
 	signedin, err := isSignedIn(ctx)
 	is.NoErr(err)            // isSignedIn error
 	is.Equal(signedin, true) // must be signed in
-	
+
 	body := readBody(r)
 	is.True(strings.Contains(body, "Hi there"))
-	
+
 }
 ```
 


### PR DESCRIPTION
Traffic from godoc.org redirects to the corresponding page on pkg.go.dev.

P.S. Thank you for talking about this package on the Go Time podcast. Always enjoy hearing from you.

Reference: https://blog.golang.org/godoc.org-redirect