### PR TITLE
Refactor New methods to use T interface

### DIFF
--- a/is-1.7.go
+++ b/is-1.7.go
@@ -33,7 +33,7 @@ func callerName(skip int) string {
 // the purpose of decorating log messages.
 const maxStackLen = 50
 
-var reIsSourceFile = regexp.MustCompile("is(-1.7)?\\.go$")
+var reIsSourceFile = regexp.MustCompile(`is(-1.7)?\.go$`)
 
 func (is *I) callerinfo() (path string, line int, ok bool) {
 	var pc [maxStackLen]uintptr

--- a/is.go
+++ b/is.go
@@ -46,7 +46,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"testing"
 )
 
 // T reports when failures occur.
@@ -186,7 +185,7 @@ func (is *I) New(t T) *I {
 //			// TODO: test
 //		})
 //	}
-func (is *I) NewRelaxed(t *testing.T) *I {
+func (is *I) NewRelaxed(t T) *I {
 	return NewRelaxed(t)
 }
 

--- a/is.go
+++ b/is.go
@@ -171,7 +171,7 @@ func (is *I) Equal(a, b interface{}) {
 //			// TODO: test
 //		})
 //	}
-func (is *I) New(t *testing.T) *I {
+func (is *I) New(t T) *I {
 	return New(t)
 }
 


### PR DESCRIPTION
## Why

There is no need to depend on `testing` package in the "production" code.

## What

- `New` and `NewRelaxed` methods accept `t T` instead of `t *t.testing`.